### PR TITLE
Add integration server to devmode settings server list

### DIFF
--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -1083,6 +1083,7 @@ local function GetLobbyTabControls()
 	end
 	if WG.Chobby.Configuration.devMode then
 		table.insert(barservers, "localhost")
+		table.insert(barservers, "server5.beyondallreason.info") -- Integration server
 	end
 
 	children[#children + 1] = ComboBox:New {


### PR DESCRIPTION
Makes testing easier without the need for custom chobby setup.